### PR TITLE
Skip Aliases (symlinks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ $ nodenv help each
 Verbose mode will print a header for each node so you can distinguish
 the output.
 
+**note**: Aliases ([nodenv-aliases][]) or symlinks are skipped.
+
 ### Examples:
 
 ```

--- a/bin/nodenv-each
+++ b/bin/nodenv-each
@@ -45,7 +45,7 @@ failed_nodes=""
 
 trap "exit 1" INT
 
-for node in $(nodenv versions --bare); do
+for node in $(nodenv versions --bare --skip-aliases); do
   if [ -n "$verbose" ]; then
     header="===[$node]==================================================================="
     header="${header:0:72}"


### PR DESCRIPTION
Aliased nodes (via nodenv-aliases or manual symlinks) mean that the same
node is invoked multiple times. (As the target node, and again for each
alias that points to said node.)

This change now omits aliases from iteration so nodenv-each now only
invokes the command for truly distinct nodes.

Fixes #4